### PR TITLE
Changed Para::Admin::BaseController inheritance for Para::ApplicationController

### DIFF
--- a/app/controllers/para/admin/base_controller.rb
+++ b/app/controllers/para/admin/base_controller.rb
@@ -1,6 +1,6 @@
 module Para
   module Admin
-    class BaseController < ApplicationController
+    class BaseController < Para::ApplicationController
       include Para::Admin::BaseHelper
 
       if Para.config.authenticate_admin_method


### PR DESCRIPTION
This was generating conflicts in my app when using identical variable names in application controller. 

Wanted to confirm that it's what we want.